### PR TITLE
Fix Package open-swift/C7 -> open-swift/C7.git

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
     name: "JSON",
     dependencies: [
-        .Package(url: "https://github.com/open-swift/C7", majorVersion: 0, minor: 12),
+        .Package(url: "https://github.com/open-swift/C7.git", majorVersion: 0, minor: 12),
     ]
 )


### PR DESCRIPTION
Avoid package errrors with fatal: destination path already exists 
and is not an empty directory.
